### PR TITLE
OpenBSD上でのビルド(cannaserver)

### DIFF
--- a/canna/widedef.h
+++ b/canna/widedef.h
@@ -31,12 +31,20 @@
 #endif
 
 #if (defined(__FreeBSD__) && __FreeBSD_version < 500000) \
-    || defined(__NetBSD__) || defined(__OpenBSD__)
+    || defined(__NetBSD__)
 # include <machine/ansi.h>
 #endif
 
-#if (defined(__FreeBSD__) && __FreeBSD_version < 500000) \
-    || defined(__NetBSD__) || defined(__OpenBSD__)
+#if defined(__OpenBSD__)
+#define _WCHAR_T_DEFINED_
+# ifdef WCHAR16
+typedef unsigned short wchar_t;
+# else
+typedef unsigned long wchar_t;
+# endif
+# define _WCHAR_T
+#elif (defined(__FreeBSD__) && __FreeBSD_version < 500000) \
+    || defined(__NetBSD__)
 # ifdef _BSD_WCHAR_T_
 #  undef _BSD_WCHAR_T_
 #  ifdef WCHAR16


### PR DESCRIPTION
最低限、canna/widedef.hの修正が必要です。
OpenBSD ports (canna-3.5b2)に含まれるパッチを使用することに加え、`#include <machine/ansi.h>`を行わない修正が必要でした。

portsに含まれる他のパッチを適用するかについては、今後の課題になります。

なお、canuumはposix_openpt()を使用したものになっておりますが、PC-UNIXではLinux/FreeBSD/DragonFlyBSD/Illumos（とmacOS）が対応します。NetBSD/OpenBSDではopenpty()を使用する必要があり、Illumos以外であればこちらも利用可能です。